### PR TITLE
Add Terrateam workflow

### DIFF
--- a/.github/workflows/terrateam.yml
+++ b/.github/workflows/terrateam.yml
@@ -1,0 +1,46 @@
+##########################################################################
+# DO NOT MODIFY
+#
+# THIS FILE SHOULD LIVE IN .github/workflows/terrateam.yml
+#
+# Looking for the Terrateam configuration file? .terrateam/config.yml.
+#
+# See https://terrateam.io/docs
+##########################################################################
+name: 'Terrateam Workflow'
+on:
+  workflow_dispatch:
+    inputs:
+      # The work-token and api-base-url are automatically passed in by the Terrateam backend
+      work-token:
+        description: 'Work Token'
+        required: true
+      api-base-url:
+        description: 'API Base URL'
+      environment:
+        description: 'Environment in which to run the action'
+        type: environment
+      runs_on:
+        description: 'runs-on configuration'
+        type: string
+        default: '"ubuntu-latest"'
+jobs:
+  terrateam:
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ${{ fromJSON(github.event.inputs.runs_on) }}
+    timeout-minutes: 1440
+    name: Terrateam Action
+    environment: '${{ github.event.inputs.environment }}'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Terrateam Action
+        id: terrateam
+        uses: terrateamio/action@v1
+        with:
+          work-token: '${{ github.event.inputs.work-token }}'
+          api-base-url: '${{ github.event.inputs.api-base-url }}'
+        env:
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+          VARIABLES_CONTEXT: ${{ toJson(vars) }}


### PR DESCRIPTION
Adds the official Terrateam GitHub Actions workflow to enable automated Terraform operations via Terrateam.
The workflow is manually triggerable, runs with OIDC, and passes repository secrets and variables to Terrateam for secure plan/apply execution across environments.
No existing behavior is changed. This only introduces the standard Terrateam workflow file under `.github/workflows/terrateam.yml`.
