### PR TITLE
Enable ssl connection

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
   dialect: 'postgresql',
   dbCredentials: {
     url: process.env.DATABASE_URL!,
+    ssl: true,
   },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { createMiddleware } from "hono/factory";
 import { drizzle } from 'drizzle-orm/node-postgres'
+import { Pool } from "pg";
 
 import articles from '$src/routes/articles'
 import search from '$src/routes/search'
@@ -12,7 +13,14 @@ import { AppContext } from '$src/types'
 
 const app = new Hono<AppContext>()
 
-const db = drizzle(process.env.DATABASE_URL!, { schema })
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: {
+    rejectUnauthorized: false
+  }
+});
+
+const db = drizzle({ schema, client: pool })
 
 const dbMiddleware = createMiddleware(async (c, next) => {
   c.set('db', db);


### PR DESCRIPTION
## Description 
Resolves the "no pg_hba.conf entry" error by enforcing SSL on the database connection. 

## Changes
- **Database:** Replaced default Drizzle connection with `pg.Pool` configured with `ssl: { rejectUnauthorized: false }` to support AWS RDS.