### PR TITLE
Remove implicit dotenv loading from Drizzle config

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import { defineConfig } from 'drizzle-kit';
 
 export default defineConfig({


### PR DESCRIPTION
## **Description**
This PR removes automatic `dotenv/config` loading from the Drizzle configuration.

**Changes**

* Removes `import 'dotenv/config'` from `drizzle.config.ts`