### PR TITLE
Remove SSL flag from semantic service DATABASE_URL

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -73,7 +73,7 @@ module "mindplex_semantic" {
     },
     {
       name  = "DATABASE_URL"
-      value = "postgresql://mindplex_admin:${var.DB_PASSWORD}@${data.terraform_remote_state.foundation.outputs.db_endpoint}:5432/mindplex_semantic?ssl=true"
+      value = "postgresql://mindplex_admin:${var.DB_PASSWORD}@${data.terraform_remote_state.foundation.outputs.db_endpoint}:5432/mindplex_semantic"
     }
   ]
 }


### PR DESCRIPTION
**Description**
This PR removes the explicit `ssl=true` query parameter from the semantic service database connection string.

**Changes**

* Updates `DATABASE_URL` to:

  * Drop `?ssl=true`
  * Rely on driver / environment defaults instead
