### PR TITLE
Resolve ssl conflict and enable auto-creation of semantic db

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
   dialect: 'postgresql',
   dbCredentials: {
     url: process.env.DATABASE_URL!,
-    ssl: true,
+    ssl: {
+      rejectUnauthorized: false
+    },
   },
 });

--- a/src/scripts/bootstrap.ts
+++ b/src/scripts/bootstrap.ts
@@ -12,6 +12,7 @@ async function bootstrap() {
     const targetDbName = urlObj.pathname.split('/')[1];
 
     urlObj.pathname = '/mindplex_shared';
+    urlObj.searchParams.delete('ssl')
     const maintenanceUrl = urlObj.toString();
 
     console.log(`Connecting to administrative DB to check for "${targetDbName}"...`);

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -73,7 +73,7 @@ module "mindplex_semantic" {
     },
     {
       name  = "DATABASE_URL"
-      value = "postgresql://mindplex_admin:${var.DB_PASSWORD}@${data.terraform_remote_state.foundation.outputs.db_endpoint}:5432/mindplex_semantic"
+      value = "postgresql://mindplex_admin:${var.DB_PASSWORD}@${data.terraform_remote_state.foundation.outputs.db_endpoint}:5432/mindplex_semantic?ssl=true"
     }
   ]
 }


### PR DESCRIPTION
# Descripton

- Update bootstrap.ts to sanitize URL and force relaxed SSL for RDS
- Update drizzle.config.ts to allow self-signed certificates
- Update Terraform to point to target 'mindplex_semantic' with strict SSL