### PR TITLE
fix migration script

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -5,7 +5,12 @@ const urlObj = new URL(databaseUrl);
 
 urlObj.searchParams.delete('ssl');
 urlObj.searchParams.delete('sslmode');
-urlObj.searchParams.set('sslmode', 'no-verify');
+const isLocal = urlObj.hostname === 'localhost' || urlObj.hostname === '127.0.0.1';
+
+if (!isLocal) {
+  urlObj.searchParams.set('sslmode', 'no-verify');
+}
+
 
 const sanitizedLog = urlObj.toString().replace(/:([^:@]+)@/, ':****@');
 console.log(`[Drizzle Config] Using sanitized URL: ${sanitizedLog}`);

--- a/drizzle/0001_equal_mauler.sql
+++ b/drizzle/0001_equal_mauler.sql
@@ -1,3 +1,8 @@
--- ALTER TABLE "articles" ALTER COLUMN "category" SET DATA TYPE text[];
+ALTER TABLE "articles"
+ADD COLUMN "category_temp" text [];
 UPDATE "articles"
-SET "category" = CAST("category" [1] AS text []);
+SET "category_temp" = ARRAY ["category"]::text []
+WHERE "category" IS NOT NULL;
+ALTER TABLE "articles" DROP COLUMN "category";
+ALTER TABLE "articles"
+    RENAME COLUMN "category_temp" TO "category";


### PR DESCRIPTION
## **Description**
This PR fixes a broken migration and stabilizes how SSL is handled during Drizzle migrations.

**What changed**

* **Migration fix**

  * Reworked the `articles.category` migration to safely convert a scalar value into `text[]`
  * Uses a temp column + data copy + rename to avoid type-cast failures and data loss
* **Drizzle SSL logic**

  * Explicitly strips `ssl` / `sslmode` from the incoming DB URL
  * Applies `sslmode=no-verify` only for non-local hosts
  * Prevents local dev from accidentally inheriting remote SSL quirks
  * Makes migration behavior consistent across environments

**Why**

* Directly casting `text → text[]` was invalid and unsafe
* Migrations were failing or behaving inconsistently depending on the DB URL source
* This makes the migration deterministic and environment-aware without touching runtime DB config

**Notes**

* `sslmode=no-verify` is intentionally scoped to non-local environments and limited to migrations
* Runtime connections remain unaffected

