### PR TITLE
Remove hardcoded SSL flags from database URLs

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -3,8 +3,6 @@ import { defineConfig } from 'drizzle-kit';
 const databaseUrl = process.env.DATABASE_URL!;
 const urlObj = new URL(databaseUrl);
 
-urlObj.searchParams.delete('ssl');
-urlObj.searchParams.delete('sslmode');
 const isLocal = urlObj.hostname === 'localhost' || urlObj.hostname === '127.0.0.1';
 
 if (!isLocal) {

--- a/src/scripts/bootstrap.ts
+++ b/src/scripts/bootstrap.ts
@@ -12,8 +12,7 @@ async function bootstrap() {
     const targetDbName = urlObj.pathname.split('/')[1];
 
     urlObj.pathname = '/mindplex_shared';
-    urlObj.searchParams.delete('ssl');
-    urlObj.searchParams.delete('sslmode');
+
     const maintenanceUrl = urlObj.toString();
 
     console.log(`Connecting to administrative DB to check for "${targetDbName}"...`);
@@ -49,10 +48,7 @@ async function bootstrap() {
 
     console.log(`Installing required extensions in "${targetDbName}"...`);
 
-
     const targetUrlObj = new URL(targetUrl);
-    targetUrlObj.searchParams.delete('ssl');
-    targetUrlObj.searchParams.delete('sslmode');
 
     const targetClient = new Client({
         connectionString: targetUrlObj.toString(),

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -73,7 +73,7 @@ module "mindplex_semantic" {
     },
     {
       name  = "DATABASE_URL"
-      value = "postgresql://mindplex_admin:${var.DB_PASSWORD}@${data.terraform_remote_state.foundation.outputs.db_endpoint}:5432/mindplex_semantic?ssl=true"
+      value = "postgresql://mindplex_admin:${var.DB_PASSWORD}@${data.terraform_remote_state.foundation.outputs.db_endpoint}:5432/mindplex_semantic"
     }
   ]
 }


### PR DESCRIPTION
## **Description**
This PR removes explicit SSL query flags from database URLs and centralizes SSL behavior at the client/config level.

**What changed**

* **Terraform**

  * Removed `?ssl=true` from `DATABASE_URL`
* **Drizzle config**

  * Stopped mutating `ssl` / `sslmode` via URL params
  * Relies on driver-level SSL configuration instead of URL hacks
* **Bootstrap script**

  * Removed URL sanitization for `ssl` / `sslmode`
  * Uses the DB URL as-is for both maintenance and target connections
