### PR TITLE
Update pagination to use `page` instead of `offset`

### DIFF
--- a/src/routes/articles/index.ts
+++ b/src/routes/articles/index.ts
@@ -29,7 +29,8 @@ articles.get('/search', vValidator('query', SearchQuerySchema), async (c) => {
     const db = c.get('db')
     const { articles, articleChunks } = c.get('schema')
     const query = c.req.valid('query')
-    const { q: searchQuery, limit, offset, fields } = query
+    const { q: searchQuery, limit, page, fields } = query
+    const offset = (page - 1) * limit
 
     if (!searchQuery) return c.json({ articles: [] })
 
@@ -104,7 +105,9 @@ articles.get('/search', vValidator('query', SearchQuerySchema), async (c) => {
 
 articles.get('/', async (c) => {
     const limit = Number(c.req.query('limit')) || 100
-    const offset = Number(c.req.query('offset')) || 0
+    const page = Math.max(1, Number(c.req.query('page')) || 1)
+
+    const offset = (page - 1) * limit
 
     const db = c.get('db')
     const { articles } = c.get('schema')
@@ -112,9 +115,16 @@ articles.get('/', async (c) => {
     const results = await db.select()
         .from(articles)
         .limit(limit)
+        .orderBy(desc(articles.id))
         .offset(offset)
 
-    return c.json(results)
+    return c.json({
+        articles: results,
+        meta: {
+            page: page,
+            limit: limit
+        }
+    })
 })
 
 articles.get('/:id', vValidator('param', ExternalIdParamsSchema), vValidator('query', GetArticleQuerySchema), async (c) => {

--- a/src/routes/articles/schema.ts
+++ b/src/routes/articles/schema.ts
@@ -5,7 +5,7 @@ import { createFieldsSchema } from '$src/utils';
 export const FORBIDDEN_COLUMNS = new Set(['embedding', 'searchVector', 'id']);
 export const ALLOWED_UPDATE_FIELDS = new Set(['title', 'teaser', 'content', 'category', 'tags', 'slug'])
 const DEFAULT_LIMIT = "10";
-const DEFAULT_OFFSET = "0";
+const DEFAULT_PAGE = "1";
 const MAX_LIMIT = 100;
 
 export const SearchQuerySchema = v.object({
@@ -20,14 +20,13 @@ export const SearchQuerySchema = v.object({
         ),
         DEFAULT_LIMIT
     ),
-    offset: v.optional(
+    page: v.optional(
         v.pipe(
             v.string(),
             v.transform(Number),
             v.integer(),
-            v.minValue(0)
         ),
-        DEFAULT_OFFSET
+        DEFAULT_PAGE
     ),
     fields: createFieldsSchema(articles, FORBIDDEN_COLUMNS),
 });

--- a/src/routes/search/index.ts
+++ b/src/routes/search/index.ts
@@ -25,7 +25,8 @@ search.get('/', vValidator('query', SearchQuerySchema), async (c) => {
     const db = c.get('db')
     const { articles, articleChunks } = c.get('schema')
     const query = c.req.valid('query')
-    const { q: searchQuery, limit, offset, fields } = query
+    const { q: searchQuery, limit, page, fields } = query
+    const offset = (page - 1) * limit
 
     if (!searchQuery) return c.json({ articles: [] })
 

--- a/src/routes/search/schema.ts
+++ b/src/routes/search/schema.ts
@@ -3,7 +3,7 @@ import { createFieldsSchema } from '$src/utils';
 import { articles } from '$src/db/schema';
 
 const DEFAULT_LIMIT = "10";
-const DEFAULT_OFFSET = "0";
+const DEFAULT_PAGE = "1";
 const MAX_LIMIT = 100;
 
 export const FORBIDDEN_COLUMNS = new Set(['embedding', 'searchVector']);
@@ -20,14 +20,13 @@ export const SearchQuerySchema = v.object({
         ),
         DEFAULT_LIMIT
     ),
-    offset: v.optional(
+    page: v.optional(
         v.pipe(
             v.string(),
             v.transform(Number),
             v.integer(),
-            v.minValue(0)
         ),
-        DEFAULT_OFFSET
+        DEFAULT_PAGE
     ),
     fields: createFieldsSchema(articles, FORBIDDEN_COLUMNS),
 });

--- a/src/routes/users/index.ts
+++ b/src/routes/users/index.ts
@@ -19,7 +19,8 @@ export const getSearchScoreSql = (query: string) => sql`
 `;
 
 users.get('/search', vValidator('query', SearchQuerySchema), async (c) => {
-    const { limit, offset, q: searchQuery } = c.req.valid('query');
+    const { limit, page, q: searchQuery } = c.req.valid('query');
+    const offset = (page - 1) * limit
 
     const db = c.get('db')
     const { users } = c.get('schema')

--- a/src/routes/users/schema.ts
+++ b/src/routes/users/schema.ts
@@ -3,7 +3,7 @@ import { users } from '$src/db/schema'
 import { createFieldsSchema } from '$src/utils'
 
 const DEFAULT_LIMIT = "10"
-const DEFAULT_OFFSET = "0"
+const DEFAULT_PAGE = "0"
 const MAX_LIMIT = 100
 
 export const FORBIDDEN_USER_COLUMNS = new Set(['searchName'])
@@ -31,14 +31,13 @@ export const SearchQuerySchema = v.object({
         ),
         DEFAULT_LIMIT
     ),
-    offset: v.optional(
+    page: v.optional(
         v.pipe(
             v.string(),
             v.transform(Number),
             v.integer(),
-            v.minValue(0)
         ),
-        DEFAULT_OFFSET
+        DEFAULT_PAGE
     ),
     fields: createFieldsSchema(users, FORBIDDEN_USER_COLUMNS),
 })


### PR DESCRIPTION
## Description

### Changes

* **Pagination Logic:** Replaced the `offset` query parameter with `page` across Articles, Search, and Users routes.
* **Internal Calculation:** Offset is now calculated as `(page - 1) * limit`.
* **Response Structure:** Updated the `GET /` articles endpoint to return a structured object:
* `articles`: The list of results.
* `meta`: Metadata containing the current `page` and `limit`.


* **Ordering:** Added default descending order by `articles.id` for the article list.
* **Schema Validation:** Updated `SearchQuerySchema` in all relevant modules to validate `page` (integer, min 1) instead of `offset`.